### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # microPop
 https://zenodo.org/badge/DOI/10.5281/zenodo.842797.svg
 
-http://dx.doi.org/10.5281/zenodo.842797
+https://doi.org/10.5281/zenodo.842797


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well.

Cheers!